### PR TITLE
Support windows, downloadValidation flag & reformatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 /* jshint esnext:true,eqeqeq:true,undef:true,lastsemic:true,strict:true,unused:true,node:true */
 
 const fs = require('fs');
+const os = require('os');
 const mv = require('mv');
 const archiver = require('archiver');
 const uuid = require('uuid/v4');
@@ -19,130 +20,162 @@ const backoffStrategy = {
 };
 
 function suggestedName(fname, fromPath){
-    "use strict";
-    if ((!fromPath) || (fromPath.length===0) || (fromPath==='/'))
-	return fname;
-    const splitFrom = fromPath.split("/").filter((s)=>(s.length>0));
+    if ((!fromPath) || (fromPath.length === 0) || (fromPath === '/')) {
+        return fname;
+    }
+    const splitFrom = fromPath.split('/').filter(s => s.length > 0);
     const index = splitFrom.length-1;
-    if (index<=0)
-	return fname;
-    const splitFname = fname.split("/").filter((s)=>(s.length>0));
-    if (splitFname.length>index)
-	return splitFname.slice(index).join("/");
+    if (index <= 0) {
+        return fname;
+    }
+    const splitFname = fname.split('/').filter(s => s.length > 0);
+    if (splitFname.length > index) {
+        return splitFname.slice(index).join('/');
+    }
     return fname;
 }   
 
-module.exports = function zipBucket(storage){
-    "use strict";
-    return function({fromBucket,fromPath,toBucket,toPath,keep,mapper,metadata,progress}){
-	if (typeof(fromBucket)!=="string") throw new Error("fromBucket require string, got:"+typeof(fromBucket));
-	if (typeof(fromPath)!=="string") throw new Error("fromPath require string, got:"+typeof(fromPath));
-	if ((!keep) && (!toBucket)) return Promise.resolve(null);
-	const manifest = [];
-	const tmpzip = '/tmp/'+uuid()+'.zip';
-	const output = fs.createWriteStream(tmpzip);
-	output.on('error', (e)=>{ throw e; });
-	const zip = archiver('zip', {
-	    zlib: { level: 9 }
-	});
-	zip.on('error', (e)=>{ throw e; });
-	zip.pipe(output);
-	function getListOfFromFiles(){
-	    return (promiseRetry((retry)=>(storage.bucket(fromBucket).getFiles({prefix:fromPath}).catch(retry)), backoffStrategy)
-		    .then((data)=>(data[0]))
-		   );
-	}
-	function zipFile(f){
-	    let pathInZip = suggestedName(f.name, fromPath);
-	    if (typeof(mapper)==='function'){
-		pathInZip = mapper(f, pathInZip);
-		if (!pathInZip)
-		    return false;
-	    }
-	    if (progress) console.log("adding gs://"+fromBucket+"/"+f.name);
-	    return new Promise(function(resolve, reject){
-		const reader = storage.bucket(fromBucket).file(f.name).createReadStream();
-		reader.on('error', (e)=>{ reject(e); });
-		reader.on('end',()=>{
-		    manifest.push([f.name,pathInZip]);
-		    resolve([f.name,pathInZip]);
-		});
-		zip.append(reader, {name: pathInZip});
-	    });
-	}
-	function zipEachFile(filelist){
-	    return pEachSeries(filelist, (f)=>(zipFile(f)));
-	}
-	function finalize(){
-	    return new Promise(function(resolve){
-		if (progress) console.log("finalizing zip file");
-		output.on('close', ()=>(resolve()));
-		zip.finalize();
-	    });
-	}
-	function uploadTheZipFile(){
-	    // see docs and example at: 
-	    // https://googlecloudplatform.github.io/google-cloud-node/#/docs/storage/1.0.0/storage/bucket?method=upload
-	    if (toBucket){
-		const options = {
-		    destination: toPath,
-		    validation: 'md5',
-		    metadata: {
-			contentType: 'application/zip'
-		    }
-		};
-		if (typeof(metadata)==='object') options.metadata.metadata = metadata;
-		if (progress) console.log("uploading zip file to gs://"+toBucket+"/"+toPath);
-		return promiseRetry((retry)=>(storage.bucket(toBucket).upload(tmpzip, options).catch(retry)), backoffStrategy);
-	    }
-	}
-	function keepTheZipFile(){
-	    if (keep){
-		if (progress) console.log("saving zip file locally to "+keep);
-		return new Promise(function(resolve,reject){
-		    mv(tmpzip,keep,(e)=>{if(e) reject(e); else setTimeout(resolve, 100); });
-		});
-	    }
-	}
-	function checkZipExistsInBucket(){
-	    if (toBucket){
-		if (progress) console.log("confirming existence of zip file at gs://"+toBucket+"/"+toPath);
-		return (promiseRetry((retry)=>(storage
-					       .bucket(toBucket)
-					       .file(toPath)
-					       .exists()
-					       .then((info)=> {if (!(info[0])) throw new Error("checkZipExistsInBucket: zip file not found in storage bucket"); })
-					       .catch(retry)
-						   ), backoffStrategy)
-		       );
-	    }
-	}
-	function deleteTheZipFile(){
-	    return new Promise(function(resolve,reject){
-		// ignore errors as keepTheZipFile may have moved/deleted the tmpzip already
-		fs.unlink(tmpzip, ()=>{ setTimeout(resolve, 100); });
-	    });
-	}
-	function successfulResult(){
-	    if (progress) console.log("finished");
-	    return {
-		keep,
-		fromBucket,
-		fromPath,
-		toBucket,
-		toPath,
-		metadata,
-		manifest
-	    };
-	}		
-	return (getListOfFromFiles()
-		.then(zipEachFile)
-		.then(finalize)
-		.then(uploadTheZipFile)
-		.then(keepTheZipFile)
-		.then(checkZipExistsInBucket)
-		.then(deleteTheZipFile)
-		.then(successfulResult)
-	       );	
-    };
+const validateOptions = ({fromBucket, fromPath}) => {
+    if (typeof(fromBucket) !== 'string') {
+        throw new Error(`fromBucket should be of type 'string', got: ${typeof(fromBucket)}`);
+    }
+    if (typeof(fromPath) !== 'string') {
+        throw new Error(`fromPath should be of type 'string', got: ${typeof(fromPath)}`);
+    }
+}
+
+module.exports = (storage) => (options) => {
+    validateOptions(options);
+    const {fromBucket, fromPath, toBucket, toPath, keep, mapper, metadata, progress, downloadValidation} = options;
+
+    if ((!keep) && (!toBucket)) {
+        return Promise.resolve(null);
+    }
+    const manifest = [];
+    const tmpzip = `${os.tmpdir()}/${uuid()}.zip`;
+    const output = fs.createWriteStream(tmpzip);
+    output.on('error', (e)=>{ throw e; });
+
+    const zip = archiver('zip', {zlib: { level: 9 }});
+    zip.on('error', (e)=>{ throw e; });
+    zip.pipe(output);
+
+    function logAction(action) {
+        if (progress) {
+            console.log(action);
+        }
+    }
+    function getListOfFromFiles() {
+        return promiseRetry((retry) => storage.bucket(fromBucket).getFiles({prefix:fromPath}).catch(retry), backoffStrategy)
+        .then((data)=>(data[0]));
+    }
+
+    function zipFile(f) {
+        let pathInZip = suggestedName(f.name, fromPath);
+        if (typeof(mapper) === 'function') {
+            pathInZip = mapper(f, pathInZip);
+            if (!pathInZip) {
+                return false;
+            }
+        }
+
+        logAction(`adding gs://${fromBucket}/${f.name}`);
+
+        return new Promise(function(resolve, reject) {
+            const reader = storage.bucket(fromBucket).file(f.name).createReadStream({validation: downloadValidation});
+            reader.on('error', (e)=>{ reject(e); });
+            reader.on('end',() => {
+                manifest.push([f.name,pathInZip]);
+                resolve([f.name,pathInZip]);
+            });
+            zip.append(reader, {name: pathInZip});
+        });
+    }
+
+    function zipEachFile(filelist) {
+        return pEachSeries(filelist, zipFile);
+    }
+
+    function finalize() {
+        return new Promise(function(resolve) {
+            logAction('finalizing zip file');
+
+            output.on('close', resolve);
+            zip.finalize();
+        });
+    }
+
+    function uploadTheZipFile() {
+        // see docs and example at: 
+        // https://googlecloudplatform.github.io/google-cloud-node/#/docs/storage/1.0.0/storage/bucket?method=upload
+        if (toBucket) {
+            const options = {
+                destination: toPath,
+                validation: 'md5',
+                metadata: {
+                    contentType: 'application/zip'
+                }
+            };
+            if (typeof(metadata) === 'object') {
+                options.metadata.metadata = metadata;
+            }
+            logAction(`uploading zip file to gs://${toBucket}/${toPath}`);
+
+            return promiseRetry((retry)=>(storage.bucket(toBucket).upload(tmpzip, options).catch(retry)), backoffStrategy);
+        }
+    }
+
+    function keepTheZipFile() {
+        if (keep) {
+            logAction(`saving zip file locally to ${keep}`);
+
+            return new Promise(function(resolve,reject) {
+                mv(tmpzip,keep,(e) => {if(e) reject(e); else setTimeout(resolve, 100); });
+            });
+        }
+    }
+
+    function checkZipExistsInBucket() {
+        if (toBucket) {
+            logAction(`confirming existence of zip file at gs://${toBucket}/${toPath}`);
+
+            return promiseRetry((retry)=>(storage
+            .bucket(toBucket)
+            .file(toPath)
+            .exists()
+            .then((info)=> {if (!(info[0])) throw new Error('checkZipExistsInBucket: zip file not found in storage bucket'); })
+            .catch(retry)
+            ), backoffStrategy)
+        }
+    }
+
+    function deleteTheZipFile() {
+        return new Promise(function(resolve,reject) {
+            // ignore errors as keepTheZipFile may have moved/deleted the tmpzip already
+            fs.unlink(tmpzip, ()=>{ setTimeout(resolve, 100); });
+        });
+    }
+
+    function successfulResult() {
+        logAction('finished');
+
+        return {
+            keep,
+            fromBucket,
+            fromPath,
+            toBucket,
+            toPath,
+            metadata,
+            manifest
+        };
+    }	
+    
+    return getListOfFromFiles()
+        .then(zipEachFile)
+        .then(finalize)
+        .then(uploadTheZipFile)
+        .then(keepTheZipFile)
+        .then(checkZipExistsInBucket)
+        .then(deleteTheZipFile)
+        .then(successfulResult);
 };


### PR DESCRIPTION
Few things in this PR:
1. Support for windows. This packages used to put the file under /tmp which is not supported for windows. I moved it to os.tmpdir() which is /tmp for unix and user tmp folder on windows
2. I have an issue with validations when downloading the file, so I added a flag to clear this validation. hope this is ok.
3. I reformatted the code so it would look better and it would be easier to read