### PR TITLE
Support parallel downloads and streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const mv = require('mv');
 const archiver = require('archiver');
 const uuid = require('uuid/v4');
 const promiseRetry = require('promise-retry');
-const pEachSeries = require('p-each-series');
+const asyncPool = require('tiny-async-pool');
 
 const backoffStrategy = {
     retries: 3,
@@ -93,7 +93,8 @@ module.exports = (storage) => (options) => {
     }
 
     function zipEachFile(filelist) {
-        return pEachSeries(filelist, zipFile);
+        const {concurrentLimit = 1} = options;
+        return asyncPool(concurrentLimit, filelist, zipFile);
     }
 
     function finalize() {

--- a/package.json
+++ b/package.json
@@ -28,10 +28,8 @@
   "dependencies": {
     "archiver": "^3.0.0",
     "commander": "^2.14.1",
-    "mv": "^2.1.1",
     "promise-retry": "^1.1.1",
-    "tiny-async-pool": "^1.0.4",
-    "uuid": "^3.2.1"
+    "tiny-async-pool": "^1.0.4"
   },
   "devDependencies": {
     "@google-cloud/storage": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "archiver": "^3.0.0",
     "commander": "^2.14.1",
     "mv": "^2.1.1",
-    "p-each-series": "^1.0.0",
     "promise-retry": "^1.1.1",
+    "tiny-async-pool": "^1.0.4",
     "uuid": "^3.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR changes two things:
1. Allow concurrent downloads of files (set to 1 by default)
2. Use stream to upload the zip to bucket as it's being built which saves memory & time
(Since I'm using streams, I don't need the temp file. So if `keep` is specified I just pipe to a stream that saves the file directly to place.)

There are few things that bother me with this PR. Please let me know what you think:
1. I had to remove the retry strategy since I'm not sure if it's possible or how to do it with streams.
2. My finalize method is **ugly**. I hate my implementation but I just can't think of a better one. I'm sure I'm missing something. If you think of something better I'd love to here.